### PR TITLE
Update node base image to 10.15.3-stretch-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.11
+FROM node:10.15.3-stretch-slim
 
 RUN \
     echo deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main > /etc/apt/sources.list.d/ansible.list && \
@@ -7,10 +7,22 @@ RUN \
     apt-get install -y --no-install-recommends \
         ansible \
         apt-transport-https \
+        bzip2 \
         ca-certificates \
         curl \
+        g++ \
+        git \
         gnupg2 \
+        gyp \
+        iputils-ping \
+        less \
+        make \
+        pigz \
+        procps \
         software-properties-common \
+        unzip \
+        vim \
+        xz-utils \
     && \
     curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
     add-apt-repository \


### PR DESCRIPTION
This update was prompted due to the jessie release is becoming EOL. Normal
apt commands no longer work without moving everything to use the Debian
archives.
This base image update has 3 parts:
1.  Change base Debian release from jessie to stretch
2.  Change base image to the "slim" version, which makes the image about
    700MB smaller.
3.  Update Node from 10.11 to 10.15.3. This version is now officially
    LTS.