### PR TITLE
feat: Use specific version of muffet

### DIFF
--- a/node10.0.0.Dockerfile
+++ b/node10.0.0.Dockerfile
@@ -1,6 +1,6 @@
 ARG NODE_VER=10.0.0-stretch
 
-FROM raviqqe/muffet as muffet
+FROM raviqqe/muffet:2.2.1 as muffet
 
 FROM node:${NODE_VER}
 ARG NODE_VER

--- a/node10.Dockerfile
+++ b/node10.Dockerfile
@@ -1,6 +1,6 @@
 ARG NODE_VER=10.15.3-stretch-slim
 
-FROM raviqqe/muffet as muffet
+FROM raviqqe/muffet:2.2.1 as muffet
 
 FROM node:${NODE_VER}
 ARG NODE_VER

--- a/node12.Dockerfile
+++ b/node12.Dockerfile
@@ -1,6 +1,6 @@
 ARG NODE_VER=12.14.1-stretch-slim
 
-FROM raviqqe/muffet as muffet
+FROM raviqqe/muffet:2.2.1 as muffet
 
 FROM node:${NODE_VER}
 ARG NODE_VER

--- a/node13.Dockerfile
+++ b/node13.Dockerfile
@@ -1,6 +1,6 @@
 ARG NODE_VER=13.8.0-stretch-slim
 
-FROM raviqqe/muffet as muffet
+FROM raviqqe/muffet:2.2.1 as muffet
 
 FROM node:${NODE_VER}
 ARG NODE_VER

--- a/node14.Dockerfile
+++ b/node14.Dockerfile
@@ -1,6 +1,6 @@
 ARG NODE_VER=14.9.0-stretch-slim
 
-FROM raviqqe/muffet as muffet
+FROM raviqqe/muffet:2.2.1 as muffet
 
 FROM node:${NODE_VER}
 ARG NODE_VER


### PR DESCRIPTION
The latest muffet has some fixes to not retrieve the same URL multiple times.
Now using 2.2.1, which has removed some v1 command line options
BREAKING CHANGE